### PR TITLE
Add fake header and allow passing null value replacements

### DIFF
--- a/src/Headers/FakeHeader.php
+++ b/src/Headers/FakeHeader.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\MailcoachMailer\Headers;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+class FakeHeader extends UnstructuredHeader
+{
+    public function __construct(bool $value = false)
+    {
+        parent::__construct('X-Mailcoach-Fake', $value);
+    }
+}

--- a/src/Headers/FakeHeader.php
+++ b/src/Headers/FakeHeader.php
@@ -6,7 +6,7 @@ use Symfony\Component\Mime\Header\UnstructuredHeader;
 
 class FakeHeader extends UnstructuredHeader
 {
-    public function __construct(bool $value = false)
+    public function __construct(bool $value = true)
     {
         parent::__construct('X-Mailcoach-Fake', $value);
     }

--- a/src/Headers/ReplacementHeader.php
+++ b/src/Headers/ReplacementHeader.php
@@ -12,7 +12,7 @@ class ReplacementHeader extends UnstructuredHeader
     {
         $this->key = $key;
 
-        parent::__construct("X-Mailcoach-Replacement-{$key}", json_encode($value));
+        parent::__construct("X-Mailcoach-Replacement-{$key}", json_encode($value ?? ''));
     }
 
     public function getKey(): string

--- a/src/Headers/ReplacementHeader.php
+++ b/src/Headers/ReplacementHeader.php
@@ -8,7 +8,7 @@ class ReplacementHeader extends UnstructuredHeader
 {
     protected string $key;
 
-    public function __construct(string $key, string|array $value)
+    public function __construct(string $key, string|array|null $value)
     {
         $this->key = $key;
 

--- a/src/MailcoachApiTransport.php
+++ b/src/MailcoachApiTransport.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerInterface;
 use Spatie\MailcoachMailer\Exceptions\EmailNotValid;
 use Spatie\MailcoachMailer\Exceptions\NoHostSet;
 use Spatie\MailcoachMailer\Exceptions\NotAllowedToSendMail;
+use Spatie\MailcoachMailer\Headers\FakeHeader;
 use Spatie\MailcoachMailer\Headers\MailerHeader;
 use Spatie\MailcoachMailer\Headers\ReplacementHeader;
 use Spatie\MailcoachMailer\Headers\TransactionalMailHeader;
@@ -106,6 +107,10 @@ class MailcoachApiTransport extends AbstractApiTransport
 
             if ($header instanceof MailerHeader) {
                 $payload['mailer'] = $header->getValue();
+            }
+
+            if ($header instanceof FakeHeader) {
+                $payload['fake'] = $header->getValue();
             }
         }
 

--- a/tests/MailcoachApiTransportTest.php
+++ b/tests/MailcoachApiTransportTest.php
@@ -97,6 +97,29 @@ it('can process the mailer header', function () {
     $transport->send($mail);
 });
 
+it('can process the fake header', function () {
+    $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+        $body = json_decode($options['body'], true);
+
+        expect($body['fake'])->toBe(true);
+
+        return new MockResponse('', ['http_code' => 204]);
+    });
+
+    $transport = (new MailcoachApiTransport('fake-api-token', $client))->setHost('domain.mailcoach.app');
+
+    $mail = (new Email())
+        ->subject('My subject')
+        ->to(new Address('to@example.com', 'To name'))
+        ->from(new Address('from@example.com', 'From name'))
+        ->text('The text content')
+        ->html('The html content');
+
+    $mail->getHeaders()->add(new FakeHeader(true));
+
+    $transport->send($mail);
+});
+
 it('throws when trying to define it twice', function () {
     $client = new MockHttpClient(function (): ResponseInterface {
         return new MockResponse('', ['http_code' => 204]);

--- a/tests/MailcoachApiTransportTest.php
+++ b/tests/MailcoachApiTransportTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\MailcoachMailer\Exceptions\NoHostSet;
+use Spatie\MailcoachMailer\Headers\FakeHeader;
 use Spatie\MailcoachMailer\Headers\MailerHeader;
 use Spatie\MailcoachMailer\Headers\ReplacementHeader;
 use Spatie\MailcoachMailer\Headers\TransactionalMailHeader;

--- a/tests/MailcoachApiTransportTest.php
+++ b/tests/MailcoachApiTransportTest.php
@@ -116,7 +116,7 @@ it('can process the fake header', function () {
         ->text('The text content')
         ->html('The html content');
 
-    $mail->getHeaders()->add(new FakeHeader(true));
+    $mail->getHeaders()->add(new FakeHeader());
 
     $transport->send($mail);
 });


### PR DESCRIPTION
I would like to test (e.g. `fake`) transactional emails.

Unfortunately this value doesn't seem to be passed to the actual payload.

With this it should pass the `fake` boolean value to the Mailcoach mailer. See https://www.mailcoach.app/api-documentation/endpoints/transactional-mails/ for details.

It would still be required to add this option to other mailers, but it would help a lot to create or extend mailers. I would like to add this to the laravel-package as well, as I don't like this solution: https://www.mailcoach.app/resources/blog/fake-it-till-you-make-it-testing-transactional-emails-with-mailcoach-in-laravel/

---

I've also added the `null` value to replacements. For instance:

```php
return [
    'tenant' => $this->getTenant()?->name,
];
```

This value may be null.